### PR TITLE
Set HTML using dangerouslySetInnerHTML.

### DIFF
--- a/src/components/fields/DescriptionField.js
+++ b/src/components/fields/DescriptionField.js
@@ -7,7 +7,9 @@ function DescriptionField(props) {
     return <div/>;
   }
   if (typeof description === "string") {
-    return <p id={id} className="field-description">{description}</p>;
+    // Set HTML-based description using dangerouslySetInnerHTML unless more performant option
+    // becomes available
+    return <p id={id} className="field-description" dangerouslySetInnerHTML={{__html: description}}></p>;
   } else {
     return <div id={id} className="field-description">{description}</div>;
   }

--- a/src/components/fields/SchemaField.js
+++ b/src/components/fields/SchemaField.js
@@ -13,7 +13,7 @@ import ObjectField from "./ObjectField";
 import StringField from "./StringField";
 import UnsupportedField from "./UnsupportedField";
 
-const REQUIRED_FIELD_SYMBOL = "*";
+const OPTIONAL_FIELD_SYMBOL = " (Optional)";
 const COMPONENT_TYPES = {
   array:   ArrayField,
   boolean: BooleanField,
@@ -42,7 +42,7 @@ function Label(props) {
   }
   return (
     <label className="control-label" htmlFor={id}>
-      {required ? label + REQUIRED_FIELD_SYMBOL : label}
+      {required ? label : label + OPTIONAL_FIELD_SYMBOL}
     </label>
   );
 }
@@ -54,7 +54,9 @@ function Help(props) {
     return <div/>;
   }
   if (typeof help === "string") {
-    return <p className="help-block">{help}</p>;
+    // Set HTML-based help using dangerouslySetInnerHTML unless more performant option
+    // becomes available
+    return <p className="help-block" dangerouslySetInnerHTML={{__html: help}}></p>;
   }
   return <div className="help-block">{help}</div>;
 }


### PR DESCRIPTION
### Reasons for making this change

Need to support HTML in descriptions and help.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature

Also add default (Optional) label to optional fields.