### PR TITLE
Resolve onSubmit issue with validation errors.

### DIFF
--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -130,11 +130,11 @@ export default class Form extends Component {
   onSubmit = (event) => {
     event.preventDefault();
     this.setState({status: "submitted"});
-
+    let stateErrorsExist = false;
     if (!this.props.noValidate) {
-      let sanitizedFormData = Object.assign({}, this.state.formData);
-      this.removeEmptyRequiredFields(this.props.schema, sanitizedFormData);
-      this.setState({ formData: sanitizedFormData }, () => {
+      let formData = Object.assign({}, this.state.formData);
+      this.removeEmptyRequiredFields(this.props.schema, formData);
+      setState(this, {formData}, () => {
         const {errors, errorSchema} = this.validate(this.state.formData);
         if (Object.keys(errors).length > 0) {
           setState(this, {errors, errorSchema}, () => {
@@ -146,14 +146,20 @@ export default class Form extends Component {
           });
           return;
         }
-      });
+        this.onInnerSubmit(event);        
+      });      
     }
+    else {
+      this.onInnerSubmit(event);
+    }
+  };
 
+  onInnerSubmit = (event) => {
     if (this.props.onSubmit) {
       this.props.onSubmit(this.state);
     }
     this.setState({status: "initial", errors: [], errorSchema: {}});
-  };
+  }
 
   getRegistry() {
     // For BC, accept passed SchemaField and TitleField props and pass them to


### PR DESCRIPTION
### Reasons for making this change

Prevent onSubmit form being called when validation errors exist.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature

