### PR TITLE
Add isSubmit flag to customValidate.

### DIFF
--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -62,9 +62,9 @@ export default class Form extends Component {
     return shouldRender(this, nextProps, nextState);
   }
 
-  validate(formData, schema) {
+  validate(formData, schema, isSubmit) {
     const {validate} = this.props;
-    return validateFormData(formData, schema || this.props.schema, validate);
+    return validateFormData(formData, schema || this.props.schema, validate, !!isSubmit);
   }
 
   renderErrors() {
@@ -142,7 +142,7 @@ export default class Form extends Component {
       let formData = Object.assign({}, this.state.formData);
       this.removeEmptyRequiredFields(this.props.schema, formData);
       setState(this, {formData}, () => {
-        const {errors, errorSchema} = this.validate(this.state.formData);
+        const {errors, errorSchema} = this.validate(this.state.formData, false, true);
         if (Object.keys(errors).length > 0) {
           setState(this, {errors, errorSchema}, () => {
             if (this.props.onError) {

--- a/src/validate.js
+++ b/src/validate.js
@@ -283,7 +283,7 @@ function formatJsonValidateResult(jsonValidateResult){
  * function, which receives the form data and an `errorHandler` object that
  * will be used to add custom validation errors for each field.
  */
-export default function validateFormData(formData, schema, customValidate) {
+export default function validateFormData(formData, schema, customValidate, isSubmit) {
   const {errors} = formatJsonValidateResult(jsonValidate(formData, schema));
   const errorSchema = toErrorSchema(errors);
 
@@ -291,7 +291,7 @@ export default function validateFormData(formData, schema, customValidate) {
     return {errors, errorSchema};
   }
 
-  const errorHandler = customValidate(formData, createErrorHandler(formData));
+  const errorHandler = customValidate(formData, createErrorHandler(formData), isSubmit);
   const userErrorSchema = unwrapErrorHandler(errorHandler);
   const newErrorSchema = mergeObjects(errorSchema, userErrorSchema, true);
   // XXX: The errors list produced is not fully compliant with the format


### PR DESCRIPTION
### Reasons for making this change

Needed a way to run special custom validation logic when submitting a form.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature

