### PR TITLE
Support "0000-01-01" as default empty value

### DIFF
--- a/src/components/widgets/EPBCDateWidget.js
+++ b/src/components/widgets/EPBCDateWidget.js
@@ -75,12 +75,15 @@ class EPBCDateWidget extends Component {
 
   constructor(props) {
     super(props);
+    // If the "null" (0000-01-01) date set to empty string so that parseDateString will set the date
+    // to an unset date state of { year: -1, month: -1, day: -1 }
     this.state = parseDateString(props.value === "0000-01-01" ? "" : props.value, props.time);
   }
 
   componentWillReceiveProps(nextProps) {
-    if (nextProps.value !== undefined) {
-      this.setState(parseDateString(nextProps.value === "0000-01-01" ? "" : nextProps.value, nextProps.time));
+    // Only change the date if it is not a "null" (0000-01-01) or undefined date
+    if (nextProps.value !== "0000-01-01" && nextProps.value !== undefined) {
+      this.setState(parseDateString(nextProps.value, nextProps.time));
     }
   }
 


### PR DESCRIPTION
### Reasons for making this change

Fix incorrect behavior when selecting Month of Feb and Day 30 or 31

If this is related to existing tickets, include links to them as well.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature

